### PR TITLE
The autogen.sh script was made executable; it also now does not annoy…

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,8 +4,3 @@ bs_dir="$(dirname $(readlink -f $0))"
 #Some versions of libtoolize don't like there being no ltmain.sh file already
 touch "${bs_dir}"/ltmain.sh
 autoreconf -fi "${bs_dir}"
-
-if test -z "$NOCONFIGURE" ; then
-	echo 'Configuring...'
-	"$bs_dir"/configure "$@"
-fi

--- a/compat.h
+++ b/compat.h
@@ -47,16 +47,6 @@ static inline int nanosleep(const struct timespec *req, struct timespec *rem)
 }
 #endif
 
-static inline int sleep(unsigned int secs)
-{
-	struct timespec req, rem;
-	req.tv_sec = secs;
-	req.tv_nsec = 0;
-	if (!nanosleep(&req, &rem))
-		return 0;
-	return rem.tv_sec + (rem.tv_nsec ? 1 : 0);
-}
-
 enum {
 	PRIO_PROCESS		= 0,
 };

--- a/configure.ac
+++ b/configure.ac
@@ -182,8 +182,9 @@ AM_CONDITIONAL([HAS_OPENCL], [test x$opencl = xyes])
 has_winpthread=false
 if test "x$have_win32" = xtrue; then
         has_winpthread=true
-        AC_CHECK_LIB(winpthread, nanosleep, , has_winpthread=false)
-        PTHREAD_LIBS=-lwinpthread
+        AC_CHECK_LIB(winpthread, nanosleep, , has_winpthread=false; PTHREAD_LIBS=-lwinpthread)
+		AC_CHECK_LIB(pthread, pthread_create, , has_winpthread=true; PTHREAD_LIBS=-lpthread)
+        
 fi
 
 if test "x$has_winpthread" != xtrue; then
@@ -197,23 +198,34 @@ AC_ARG_ENABLE([adl],
 	[adl=$enableval]
 	)
 
+AC_ARG_ENABLE([adl-checks],
+	[AC_HELP_STRING([--disable-adl-checks],[Disable file existence check and assume ADL headers are in place (for cross compiling)])], [],
+	[adlchecks=$enableval]
+	)
+
 scrypt="no"
 
 if test "$found_opencl" = 1; then
-	if test "x$adl" != xno; then
-		ADL_CPPFLAGS=
-		AC_CHECK_FILE([$srcdir/ADL_SDK/adl_sdk.h], [have_adl=true; ADL_CPPFLAGS=-I$srcdir], have_adl=false,)
-		if test x$have_adl+$have_cgminer_sdk = xfalse+true; then
-			AC_CHECK_FILE([$CGMINER_SDK/include/ADL_SDK/adl_sdk.h], [have_adl=true; ADL_CPPFLAGS=-I$CGMINER_SDK/include], have_adl=false,)
-		fi
-		if test x$have_adl = xtrue
-		then
-			AC_DEFINE([HAVE_ADL], [1], [Defined if ADL headers were found])
-		else
-			DLOPEN_FLAGS=""
+	if test "x$adlchecks" != xyes; then
+		adl=yes
+		have_adl=true
+		ADL_CPPFLAGS=-I$CGMINER_SDK/include
+		AC_DEFINE([HAVE_ADL], [1], [Defined if ADL headers were found])
+	else
+		if test "x$adl" != xno; then
+			ADL_CPPFLAGS=
+			AC_CHECK_FILE([$srcdir/ADL_SDK/adl_sdk.h], [have_adl=true; ADL_CPPFLAGS=-I$srcdir], have_adl=false,)
+			if test x$have_adl+$have_cgminer_sdk = xfalse+true; then
+				AC_CHECK_FILE([$CGMINER_SDK/include/ADL_SDK/adl_sdk.h], [have_adl=true; ADL_CPPFLAGS=-I$CGMINER_SDK/include], have_adl=false,)
+			fi
+			if test x$have_adl = xtrue
+			then
+				AC_DEFINE([HAVE_ADL], [1], [Defined if ADL headers were found])
+			else
+				DLOPEN_FLAGS=""
+			fi
 		fi
 	fi
-
 	AC_ARG_ENABLE([scrypt],
 		[AC_HELP_STRING([--enable-scrypt],[Compile support for scrypt litecoin mining (default disabled)])],
 		[scrypt=$enableval]


### PR DESCRIPTION
…ing configure for you (and do it wrong in the process.) The sleep() function was removed from compat.h - I use a custom MinGW-w64 toolchain with pthreads-w32, and sleep() is provided just fine. If left there, it will cause linker errors for the multiply defined symbol. The configure.ac file (which generates the configure script) now includes an option to disable the previously mandatory ADL header file checks - this check will error out unconditionally when cross compiling. It may now be disabled by --disable-adl-checks, which defaults to off (meaning the checks stay on by default.) The configure script also now will not assume winpthread is the ONLY kind of pthread library you can use on Windows, and will check for both winpthreads and a REAL Windows pthreads library (like pthreads-w32, which I use because it supplies more of the pthread library than winpthreads) - it will then handle linking accordingly, i.e. -lwinpthread in the former case, and -lpthread in the latter. The variable has_winpthread is still set to true if another Windows pthread lib is found - this is not a mistake, it is required for the code to work properly. Someone should rename that at some point.
